### PR TITLE
[node-fetch] require to use major version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/ambassify/fetch#readme",
   "dependencies": {
-    "node-fetch": "*",
+    "node-fetch": "^2.0.0",
     "unfetch": "*"
   }
 }


### PR DESCRIPTION
Allowing any version of node fetch could cause some weird behaviour when your project also includes other dependencies that might require a specific version of node-fetch. There are some inconsistencies (mostly in Headers implementation) that could cause unexpected behaviour.

I suggest releasing a major version for this; will probably be safest to prevent any unforeseen problems in packages that assume it's node-fetch < 2.