### PR TITLE
[browser] fix undefined userAgent

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,7 +2,11 @@
  * Edge 14's fetch implementation is a buggy mess
  * https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8653298/
  */
-if (window.navigator.userAgent.indexOf('Edge/14') > -1)
-    delete window.fetch;
+if (
+    window &&
+    window.navigator &&
+    window.navigator.userAgent &&
+    window.navigator.userAgent.indexOf('Edge/14') > -1
+) delete window.fetch;
 
 module.exports = window.fetch || require('unfetch').default || require('unfetch');


### PR DESCRIPTION
In react-native for example, the `navigator` object does not contain a `userAgent` property.