### PR TITLE
fix(deps): lock unfetch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/ambassify/fetch#readme",
   "dependencies": {
     "node-fetch": "^2.0.0",
-    "unfetch": "*",
+    "unfetch": "^4.2.0",
     "uuid": "^7.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Version 5 introduced package exports and not all our webpack
projects are compatible. Problem discovery in manage