### PR TITLE
fix(node): set default `duplex` value

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,9 @@ function getImplementation() {
         options = Object.assign({}, options || {});
         options.headers = Object.assign({}, headers, options.headers || {});
 
+        if (options.body && typeof options.duplex === 'undefined')
+            options.duplex = 'half';
+
         return impl(url, options);
     };
 }


### PR DESCRIPTION
'half' is considered default behaviour at this point in time.
unidici however requires setting `duplex` when streaming a body, this
takes that requirement away and makes the usage of fetch more
consistent.